### PR TITLE
Task-43991 Rework userHandler to simplify the user fetching when quer…

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/Query.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/Query.java
@@ -20,6 +20,7 @@ package org.exoplatform.services.organization;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Created by The eXo Platform SAS . Author : Tuan Nguyen
@@ -39,73 +40,83 @@ public class Query implements Serializable
    private Date from_;
 
    private Date to_;
-
+   
+   private List<String> groups;
+   
    public Query()
    {
    }
-
+   
    public String getUserName()
    {
       return userName_;
    }
-
+   
    public void setUserName(String s)
    {
       userName_ = s;
    }
-
+   
    public String getFirstName()
    {
       return fname_;
    }
-
+   
    public void setFirstName(String s)
    {
       fname_ = s;
    }
-
+   
    public String getLastName()
    {
       return lname_;
    }
-
+   
    public void setLastName(String s)
    {
       lname_ = s;
    }
-
+   
    public String getEmail()
    {
       return email_;
    }
-
+   
    public void setEmail(String s)
    {
       email_ = s;
    }
-
+   
    public Date getFromLoginDate()
    {
       return from_;
    }
-
+   
    public void setFromLoginDate(Date d)
    {
       from_ = d;
    }
-
+   
    public Date getToLoginDate()
    {
       return to_;
    }
-
+   
    public void setToLoginDate(Date d)
    {
       to_ = d;
    }
-
+   
+   public List<String> getGroups() {
+      return groups;
+   }
+   
+   public void setGroups(List<String> groups) {
+      this.groups = groups;
+   }
+   
    public boolean isEmpty()
    {
-      return email_ == null && fname_ == null && from_ == null && lname_ == null && to_ == null && userName_ == null;
+      return email_ == null && fname_ == null && from_ == null && lname_ == null && to_ == null && userName_ == null && groups == null;
    }
 }

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
@@ -155,7 +155,7 @@ public interface UserHandler
     *          group
     * @return return a page list iterator of a group of the user in the database
     * @throws Exception
-    * @deprecated use {@link #findUsersByGroupId(String)} instead
+    * @deprecated use {@link #findUsersByQuery(Query)} instead
     */
    @Deprecated
    PageList<User> findUsersByGroup(String groupId) throws Exception;
@@ -163,26 +163,15 @@ public interface UserHandler
    /**
     * This method should search and return the list of the users in a given
     * group. This method is equivalent to <code>findUsersByGroupId(groupId, UserStatus.ENABLED)</code>
-    *
+ 
     * @param groupId id of the group. The return users list should be in this
     *          group
     * @return return a page list iterator of a group of the user in the database
     * @throws Exception any exception
+    * @deprecated user {@link #findUsersByQuery(Query)} instead
     */
+   @Deprecated
    ListAccess<User> findUsersByGroupId(String groupId) throws Exception;
-   
-   /**
-    * This method search for the users in a given  groups according to a search criteria
-    *
-    * @param query      The query object contains the search criteria.
-    * @param groupIds
-    * @param userStatus
-    * @return return the found users in a page list according to the query and groups.
-    * @throws Exception any exception
-    */
-   default ListAccess<User> findUsersByQuery(Query query, List<String> groupIds, UserStatus userStatus) throws Exception {
-      throw new UnsupportedOperationException();
-   }
 
    /**
     * This method should search and return the list of the users in a given
@@ -194,7 +183,9 @@ public interface UserHandler
     *              If set to <code>UserStatus.ENABLED</code> only enabled users will be returned.
     * @return return a page list iterator of a group of the user in the database
     * @throws Exception any exception
+    * @deprecated user {@link #findUsersByQuery(Query, UserStatus)} instead
     */
+   @Deprecated
    ListAccess<User> findUsersByGroupId(String groupId, UserStatus status) throws Exception;
 
    /**

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/cache/CacheableUserHandlerImpl.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/cache/CacheableUserHandlerImpl.java
@@ -146,13 +146,6 @@ public class CacheableUserHandlerImpl implements UserHandler
    {
       return userHandler.findUsersByGroupId(groupId);
    }
-
-   /**
-    * {@inheritDoc}
-    */
-   public ListAccess<User> findUsersByQuery(Query query, List<String> groupIds, UserStatus userStatus) throws Exception {
-      return userHandler.findUsersByQuery(query, groupIds, userStatus);
-   }
    
    /**
     * {@inheritDoc}


### PR DESCRIPTION
…ying with a group

Before this fix, when using UserHandler to query user, by providing one or more groups, we use different method and code duplication
This fix refactor user fetching, by adding the groups list in the query, and use it to fetch users, in only one central function : findUsersByQuery