### PR TITLE
Task-46145 : Fix jacoco execution

### DIFF
--- a/exo.core.component.database/pom.xml
+++ b/exo.core.component.database/pom.xml
@@ -140,7 +140,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.core.component.document/pom.xml
+++ b/exo.core.component.document/pom.xml
@@ -214,7 +214,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-               <argLine>-Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+               <argLine>${argLine} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
                <systemProperties>
                   <property>
                      <name>emma.coverage.out.file</name>

--- a/exo.core.component.organization.api/pom.xml
+++ b/exo.core.component.organization.api/pom.xml
@@ -102,7 +102,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.core.component.security.core/pom.xml
+++ b/exo.core.component.security.core/pom.xml
@@ -69,7 +69,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.core.component.xml-processing/pom.xml
+++ b/exo.core.component.xml-processing/pom.xml
@@ -100,7 +100,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>


### PR DESCRIPTION
Before this fix, jacoco does not fail if target ratio is not reached.
This is due to the fact that surefire override jacoco argLine and jacoco option are not more usable
This fix follow this https://stackoverflow.com/questions/12269558/maven-jacoco-plugin-error and re-add ${argLine} in surefire option, so that jacoco is able to find his options