### PR TITLE
Task-50856 : [Active directory sycnhronization] AD group users aren't synchronized with the eXo group

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/GroupHandler.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/GroupHandler.java
@@ -82,6 +82,21 @@ public interface GroupHandler
    void saveGroup(Group group, boolean broadcast) throws Exception;
 
    /**
+    * Use this method to move a group in the group tree
+    * it will only remove the relation between originGroup.parentId and originGroup.id,
+    * and add a relation between targetGroup.parentId and originGroup.id
+    *
+    * @param parentOriginGroup The parent group of the group to move
+    * @param parentTargetGroup The parent group where to move the group
+    * @param parentTargetGroup The group object to move
+    * @throws Exception An exception is thrown if the method cannot access the
+    *           database or any listener fail to handle the event
+    */
+   default void moveGroup(Group parentOriginGroup, Group parentTargetGroup,Group groupToMove) throws Exception {
+      throw new UnsupportedOperationException();
+   }
+
+   /**
     * Use this method to remove a group from the group database. If the group has
     * the children group. The method should not remove the group and throw and
     * exception

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/cache/CacheableGroupHandlerImpl.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/cache/CacheableGroupHandlerImpl.java
@@ -221,4 +221,16 @@ public class CacheableGroupHandlerImpl implements GroupHandler
       groupCache.put(group.getId(), group);
    }
 
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public void moveGroup(Group parentOriginGroup, Group parentTargetGroup,Group groupToMove) throws Exception
+   {
+      groupHandler.moveGroup(parentOriginGroup, parentTargetGroup,groupToMove);
+   }
+
+
+
+
 }


### PR DESCRIPTION
Before this fix, when an AD group is member of more than one group, he is synchronized at root group level. When a parent of this group is removed (he now have only one parent), he is sync ad children of his parent. But the  information is not propagated to idm database. So, when a user, member of a group like this connect, he is ejected from this group.
This fix allow to detect that a group moves from the root level to a non root level, and propagate the information to the IDM database