### PR TITLE
MAINT-53372: Add preSave and postSave support for external users in userHandler and UserEventListener

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserEventListener.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserEventListener.java
@@ -71,6 +71,20 @@ public class UserEventListener extends BaseComponentPlugin
    }
 
    /**
+    * This method is called before the user is persisted to the database.
+    *
+    * @param user The user to be saved
+    * @param isNew if the user is a new record in the database or not
+    * @throws Exception The developer can decide to throw an exception or not. If
+    *           the listener throw an exception, the organization service should
+    *           not save/update the user to the database
+    * @param isExternal if the user is external or internal
+    */
+   public void preSave(User user, boolean isNew, boolean isExternal) throws Exception
+   {
+   }
+
+   /**
     * This method is called after the user has been saved but not committed yet
     * 
     * @param user The user instance has been saved.
@@ -81,6 +95,21 @@ public class UserEventListener extends BaseComponentPlugin
     *           userHandler.createUser(..) or UserHandler.saveUser(..) is called.
     */
    public void postSave(User user, boolean isNew) throws Exception
+   {
+   }
+
+   /**
+    * This method is called after the user has been saved but not committed yet
+    *
+    * @param user The user instance has been saved.
+    * @param isNew if the user is a new record in the database or not
+    * @throws Exception The developer can decide to throw the exception or not.
+    *           If the method throw an exception. The organization service should
+    *           role back the data to the state before the method
+    *           userHandler.createUser(..) or UserHandler.saveUser(..) is called.
+    * @param isExternal if the user is external or internal
+    */
+   public void postSave(User user, boolean isNew, boolean isExternal) throws Exception
    {
    }
 

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
@@ -71,6 +71,24 @@ public interface UserHandler
    void createUser(User user, boolean broadcast) throws Exception;
 
    /**
+    * This method is used to persist a new user object.
+    *
+    * @param user The user object to save
+    * @param broadcast If the broadcast value is true , then the UserHandler
+    *          should broadcast the event to all the listener that register with
+    *          the organization service. For example, the portal service register
+    *          an user event listener with the organization service. when a new
+    *          account is created, a portal configuration should be created for
+    *          the new user account at the same time. In this case the portal
+    *          user event listener will be called in the createUser method.
+    * @param isExternal if the user is external or internal
+    * @throws Exception The exception can be thrown if the UserHandler
+    *           cannot persist the user object or any listeners fail to handle
+    *           the user event.
+    */
+   void createUser(User user, boolean isExternal, boolean broadcast) throws Exception;
+
+   /**
     * This method is used to update an existing User object
     * 
     * @param user The user object to update

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/cache/CacheableUserHandlerImpl.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/cache/CacheableUserHandlerImpl.java
@@ -94,6 +94,14 @@ public class CacheableUserHandlerImpl implements UserHandler
    /**
     * {@inheritDoc}
     */
+   @Override
+   public void createUser(User user, boolean isExternal, boolean broadcast) throws Exception {
+      userHandler.createUser(user, isExternal, broadcast);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
    public User createUserInstance()
    {
       return userHandler.createUserInstance();

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/mock/DummyOrganizationService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/mock/DummyOrganizationService.java
@@ -249,6 +249,12 @@ public class DummyOrganizationService extends BaseOrganizationService
       {
       }
 
+
+      @Override
+      public void createUser(User user, boolean isExternal, boolean broadcast) throws Exception {
+
+      }
+
       public void saveUser(User user, boolean broadcast) throws Exception
       {
       }


### PR DESCRIPTION
ISSUE: when create user with the `organizationService`, there is no a dedicated creation method for external users and also a dedicated listeners for this action, which prevent having a complete control on the actions that will be triggered during the creation of each type of these users.
FIX: This PR will add a support for creating external users in the `userhandler` by add a new create function with `isExternal` flag and also a `postSave` and `preSave` with the `isExternal` flag in the `UserEventListener` 