### PR TITLE
TASK-54025 Allow to extend Authenticator service

### DIFF
--- a/exo.core.component.organization.api/pom.xml
+++ b/exo.core.component.organization.api/pom.xml
@@ -31,7 +31,7 @@
    <name>eXo PLF Core :: Component :: Organization Service API</name>
    <description>API of Organization Service of Exoplatform SAS 'eXo Core' project.</description>
    <properties>
-      <exo.test.coverage.ratio>0.09</exo.test.coverage.ratio>
+      <exo.test.coverage.ratio>0.10</exo.test.coverage.ratio>
    </properties>
    <dependencies>
       <dependency>

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/auth/AuthenticatorPlugin.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/auth/AuthenticatorPlugin.java
@@ -1,0 +1,37 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.services.organization.auth;
+
+import org.exoplatform.container.component.BaseComponentPlugin;
+import org.exoplatform.services.security.Credential;
+
+/**
+ * A component Plugin that could be injected in
+ * {@link OrganizationAuthenticatorImpl} to extend the way to authenticate users
+ */
+public abstract class AuthenticatorPlugin extends BaseComponentPlugin {
+
+  /**
+   * Authenticate user and return userId which can be different to username.
+   * 
+   * @param credentials - list of users credentials (such as name/password, X509
+   *          certificate etc)
+   * @return userId the user's identifier.
+   */
+  public abstract String validateUser(Credential[] credentials);
+
+}

--- a/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/auth/TestOrganizationAuthenticator.java
+++ b/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/auth/TestOrganizationAuthenticator.java
@@ -20,6 +20,8 @@ package org.exoplatform.services.organization.auth;
 
 import junit.framework.TestCase;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.container.StandaloneContainer;
 import org.exoplatform.services.organization.DisabledUserException;
 import org.exoplatform.services.organization.OrganizationService;
@@ -33,6 +35,7 @@ import org.exoplatform.services.security.PasswordCredential;
 import org.exoplatform.services.security.UsernameCredential;
 
 import java.net.URL;
+import java.util.List;
 
 import javax.security.auth.login.LoginException;
 
@@ -86,16 +89,83 @@ public class TestOrganizationAuthenticator extends TestCase
 
    public void testAuthenticator() throws Exception
    {
-      assertNotNull(authenticator);
-      assertTrue(authenticator instanceof OrganizationAuthenticatorImpl);
-      Credential[] cred = new Credential[]{new UsernameCredential("admin"), new PasswordCredential("admin")};
-      String userId = authenticator.validateUser(cred);
-      assertEquals("admin", userId);
-      Identity identity = authenticator.createIdentity(userId);
-      assertTrue(identity.isMemberOf("/platform/administrators", "manager"));
-      assertTrue(identity.getGroups().size() > 0);
-   }
-   
+     assertNotNull(authenticator);
+     assertTrue(authenticator instanceof OrganizationAuthenticatorImpl);
+     Credential[] cred = new Credential[]{new UsernameCredential("admin"), new PasswordCredential("admin")};
+     String userId = authenticator.validateUser(cred);
+     assertEquals("admin", userId);
+     Identity identity = authenticator.createIdentity(userId);
+     assertTrue(identity.isMemberOf("/platform/administrators", "manager"));
+     assertTrue(identity.getGroups().size() > 0);
+  }
+
+   public void testAuthenticatorPlugin() throws Exception
+   {
+     OrganizationAuthenticatorImpl organizationAuthenticatorImpl = (OrganizationAuthenticatorImpl) authenticator;
+     List<AuthenticatorPlugin> originalPlugins = organizationAuthenticatorImpl.getPlugins();
+     try {
+       String username = "0xABCD";
+       String userId = "testuser";
+       String password = "0xDCBA";
+
+       Credential[] cred = new Credential[] { new UsernameCredential(username), new PasswordCredential(password) };
+
+       try {
+         organizationAuthenticatorImpl.validateUser(cred);
+         fail("Must fail with invalid credentials");
+       } catch (LoginException e) {
+         // Expected
+       }
+
+       // Add plugins that invalidate credentials after and before valid one
+       organizationAuthenticatorImpl.addAuthenticatorPlugin(new AuthenticatorPlugin() {
+         @Override
+         public String validateUser(Credential[] credentials) {
+           throw new IllegalStateException("Fake Login Error");
+         }
+       });
+
+       organizationAuthenticatorImpl.addAuthenticatorPlugin(new AuthenticatorPlugin() {
+         @Override
+         public String validateUser(Credential[] credentials) {
+           boolean valid = credentials != null && credentials.length == 2
+               && StringUtils.equals(username, ((UsernameCredential) credentials[0]).getUsername())
+               && StringUtils.equals(password, ((PasswordCredential) credentials[1]).getPassword());
+           return valid ? userId : null;
+         }
+       });
+
+       organizationAuthenticatorImpl.addAuthenticatorPlugin(new AuthenticatorPlugin() {
+         @Override
+         public String validateUser(Credential[] credentials) {
+           return null;
+         }
+       });
+
+       String authenticatedUser = organizationAuthenticatorImpl.validateUser(cred);
+       assertEquals(userId, authenticatedUser);
+
+       Identity identity = organizationAuthenticatorImpl.createIdentity(userId);
+       assertTrue(identity.isMemberOf("/platform/users", "member"));
+       assertFalse(identity.getGroups().isEmpty());
+
+       try {
+         organizationAuthenticatorImpl.validateUser(new Credential[] { new UsernameCredential("badUsername"), new PasswordCredential(password) });
+         fail("Must fail with invalid credentials");
+       } catch (LoginException e) {
+         // Expected
+       }
+
+       try {
+         organizationAuthenticatorImpl.validateUser(new Credential[] { new UsernameCredential(username), new PasswordCredential("badPassword") });
+         fail("Must fail with invalid credentials");
+       } catch (LoginException e) {
+         // Expected
+       }
+     } finally {
+       organizationAuthenticatorImpl.setPlugins(originalPlugins);
+     }
+  }
 
    public void testGetLastExceptionOnValidateUser() throws Exception
    {

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/jaas/DefaultLoginModule.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/jaas/DefaultLoginModule.java
@@ -116,9 +116,9 @@ public class DefaultLoginModule extends AbstractLoginModule
             Credential[] credentials =
                new Credential[]{new UsernameCredential(username), new PasswordCredential(password)};
 
-            String userId = authenticator.validateUser(credentials);
-            identity = authenticator.createIdentity(userId);
-            sharedState.put("javax.security.auth.login.name", userId);
+            username = authenticator.validateUser(credentials);
+            identity = authenticator.createIdentity(username);
+            sharedState.put("javax.security.auth.login.name", username);
 
             subject.getPrivateCredentials().add(password);
             subject.getPublicCredentials().add(new UsernameCredential(username));


### PR DESCRIPTION
Prior to this change, the Authenticator Service isn't extensible to allow different methods of Username/Password validation unless the whole Service is overridden. This change allows to extend Authenticator Service by implementing a dedicated Component Plugin injected by Kernel IoC configuration.