### PR TITLE
TASK-54025 Allow to authenticate with blank username or password

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/auth/OrganizationAuthenticatorImpl.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/auth/OrganizationAuthenticatorImpl.java
@@ -157,7 +157,7 @@ public class OrganizationAuthenticatorImpl implements Authenticator
          }
       }
       boolean success = false;
-      if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+      if (username != null && password != null) {
         if (this.encrypter != null)
            password = new String(encrypter.encrypt(password.getBytes()));
   

--- a/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/auth/TestOrganizationAuthenticator.java
+++ b/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/auth/TestOrganizationAuthenticator.java
@@ -27,12 +27,7 @@ import org.exoplatform.services.organization.DisabledUserException;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserHandler;
-import org.exoplatform.services.security.Authenticator;
-import org.exoplatform.services.security.ConversationRegistry;
-import org.exoplatform.services.security.Credential;
-import org.exoplatform.services.security.Identity;
-import org.exoplatform.services.security.PasswordCredential;
-import org.exoplatform.services.security.UsernameCredential;
+import org.exoplatform.services.security.*;
 
 import java.net.URL;
 import java.util.List;
@@ -98,6 +93,15 @@ public class TestOrganizationAuthenticator extends TestCase
      assertTrue(identity.isMemberOf("/platform/administrators", "manager"));
      assertTrue(identity.getGroups().size() > 0);
   }
+
+   public void testAuthenticateWithEmptyPassword() throws Exception
+   {
+     assertNotNull(authenticator);
+     assertTrue(authenticator instanceof OrganizationAuthenticatorImpl);
+     Credential[] cred = new Credential[]{new UsernameCredential(IdentityConstants.ANONIM), new PasswordCredential("")};
+     String userId = authenticator.validateUser(cred);
+     assertEquals(IdentityConstants.ANONIM, userId);
+   }
 
    public void testAuthenticatorPlugin() throws Exception
    {


### PR DESCRIPTION
Prior to this change, due to a recent commit, a check of just nullability for username and password was made. This change reverts the check on empty string to make it a chack on nullability only.