### PR TITLE
54978: avoid invoking login listeners when session is already saved

### DIFF
--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationRegistry.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationRegistry.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.services.security;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.container.spi.DefinitionByType;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
@@ -135,8 +136,13 @@ public final class ConversationRegistry
     */
    public void register(StateKey key, ConversationState state)
    {
-      if(states.get(key) == null) {
-         states.put(key, state);
+      String userId = state.getIdentity().getUserId();
+      // We will broadcast login event if :
+      // 1- session is not already registered -> session ID is not in the states map keys
+      // 2- user is not already logged-in (there is no registered state with the same userID)
+      boolean broadcast = states.get(key) == null && StringUtils.isNotBlank(userId) && getStateKeys(userId).isEmpty();
+      states.put(key, state);
+      if (broadcast) {
          try {
             listenerService.broadcast("exo.core.security.ConversationRegistry.register", this, state);
          } catch (Exception e) {

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationRegistry.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationRegistry.java
@@ -135,21 +135,13 @@ public final class ConversationRegistry
     */
    public void register(StateKey key, ConversationState state)
    {
-      // supposed that "old" stored value (if any) is no more useful in registry
-      // so we "push" it
-      // for example - we have to do "login" register with username as a key
-      // but it is possible to have more than one state (session) with the same
-      // UID so old one will be pushed possible drawback of this case if
-      // another "same" login occurs between
-      // login and possible use - first state will be just missed
-      states.put(key, state);
-      try
-      {
-         listenerService.broadcast("exo.core.security.ConversationRegistry.register", this, state);
-      }
-      catch (Exception e)
-      {
-         LOG.error("Broadcast message filed ", e);
+      if(states.get(key) == null) {
+         states.put(key, state);
+         try {
+            listenerService.broadcast("exo.core.security.ConversationRegistry.register", this, state);
+         } catch (Exception e) {
+            LOG.error("Broadcast message filed ", e);
+         }
       }
    }
 

--- a/exo.core.component.security.core/src/test/java/org/exoplatform/services/security/TestSessionRegistry.java
+++ b/exo.core.component.security.core/src/test/java/org/exoplatform/services/security/TestSessionRegistry.java
@@ -119,6 +119,8 @@ public class TestSessionRegistry extends TestCase
                ConversationState cs = (ConversationState)event.getData();
                assertSame(s, cs);
                cs.setAttribute("payload", payload);
+               int numberOfCalls = cs.getAttribute("calls") != null ? (int) cs.getAttribute("calls") : 0;
+               cs.setAttribute("calls", numberOfCalls + 1);
             }
             catch (AssertionFailedError error)
             {
@@ -171,6 +173,12 @@ public class TestSessionRegistry extends TestCase
       assertNotNull(registry.getState(key));
       assertEquals(id, registry.getState(key).getIdentity());
       assertSame(payload, s.getAttribute("payload"));
+
+      StateKey key1 = new SimpleStateKey("key1");
+      //
+      registry.register(key1, s);
+
+      assertEquals(1, s.getAttribute("calls"));
 
       //
       registry.unregister(key);


### PR DESCRIPTION
When a user login to the system, we check if the session is already saved in the conversation states before re-invoking the listeners. 
This fix : 
 - avoids having multiple registration of the same HTTP session.
 - IF a user is already logged-in, it updates the state in the conversationRegistry but it won't invoke related listeners
