### PR TITLE
Task-54884 : External users receive notification of published news from a space of which they are not a member

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserProfile.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserProfile.java
@@ -67,7 +67,7 @@ public interface UserProfile extends Serializable
     * The predefine attributes of the exoplatform. Those keys are currently used
     * in the exo forum
     */
-   final static public String[] OTHER_KEYS = {"user.other-info.avatar.url", "user.other-info.signature",};
+   final static public String[] OTHER_KEYS = {"user.other-info.avatar.url", "user.other-info.signature","user.other-info.external"};
 
    /**
     * @return the username, the identifier of an user profile instance


### PR DESCRIPTION
Before this fix, the external status is tested in gatein profile, but is only present in social profile.
This commit update the listener which update the gatein profile when the social profile change to take care of this modification.
After that, as the external info is present in gatein profile, notification will be able to check it correctly.