### PR TITLE
TASK-58023: Add a SecurityCheckAuthentication Plugin

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/auth/SecurityCheckAuthenticationPlugin.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/auth/SecurityCheckAuthenticationPlugin.java
@@ -1,0 +1,29 @@
+package org.exoplatform.services.organization.auth;
+
+import org.exoplatform.container.component.BaseComponentPlugin;
+import org.exoplatform.services.organization.User;
+
+public abstract class SecurityCheckAuthenticationPlugin extends BaseComponentPlugin {
+
+  /**
+   * check user authentication depends on the specified logic in the plugin
+   *
+   * @param user Target user to be authenticated
+   * @throws Exception
+   */
+  public abstract void doCheck(User user) throws Exception;
+
+  /**
+   * Invoked when the check on the authentication is failed
+   * 
+   * @param userName Target username
+   */
+  public abstract void onCheckFail(String userName);
+
+  /**
+   * Invoked when the check on the authentication is succeeded
+   * 
+   * @param userName Target username
+   */
+  public abstract void onCheckSuccess(String userName);
+}


### PR DESCRIPTION
This PR introduces  a new plugin called SecurityCheckAuthenticationPlugin wich will be used in the OrganizationAuthenticater to create some logic checks during the athentication phase, when the authentication fails
and when the athentication suceeds , which will be done by its three genric functions (doCheck, onCheckFail, onCheckSuccess).