### PR TITLE
fix: Server is unable to start with ldap - EXO-61736 - Meeds-io/meeds#535 

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
@@ -120,7 +120,7 @@ public class IDMExternalStoreImportService implements Startable {
     } catch (Exception e) {
       LOG.error("Error while configuring external store", e);
     } finally {
-      forceCloseTransaction();
+      RequestLifeCycle.end();
     }
   }
 


### PR DESCRIPTION
Prior to this change, when server start fails when starting it with ldap due to the fact that an exception is raised in start function of the `IDMExternalStoreImportService` because of an attempt to close a closed transaction during server startup with an `illegalStateException`. 
This PR should simply close the opened transaction in safe way to prevent such issue
