### PR TITLE
fix: remove unused transitive dependency cxf client - EXO-64344

### DIFF
--- a/exo.core.component.document/pom.xml
+++ b/exo.core.component.document/pom.xml
@@ -126,6 +126,10 @@
                <artifactId>tika-core</artifactId>
             </exclusion>
             <exclusion>
+               <groupId>org.apache.cxf</groupId>
+               <artifactId>cxf-rt-rs-client</artifactId>
+            </exclusion>
+            <exclusion>
                <groupId>org.apache.geronimo.specs</groupId>
                <artifactId>geronimo-stax-api_1.0_spec</artifactId>
             </exclusion>


### PR DESCRIPTION
This will remove an unused transitive dependency cxf-rt-rs-client that causes issues in Unit tests
