### PR TITLE
fix: Fix import of IDM data - MEED-7000 - Meeds-io/meeds#2098

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/BaseOrganizationService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/BaseOrganizationService.java
@@ -107,10 +107,11 @@ public abstract class BaseOrganizationService implements OrganizationService, St
     for (OrganizationServiceInitializer listener : listeners_) {
       try {
         listener.init(this, entityType);
-      } catch (Exception ex) {
+      } catch (Exception e) {
         LOG.warn("Failed start Organization Service {}, probably because of configuration error. Error occurs when initialize {}",
                  getClass().getName(),
-                 listener.getClass().getName());
+                 listener.getClass().getName(),
+                 e);
       }
     }
   }

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/BaseOrganizationService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/BaseOrganizationService.java
@@ -22,6 +22,9 @@ import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.component.ComponentPlugin;
 import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
 import org.picocontainer.Startable;
 
 import java.util.ArrayList;
@@ -31,120 +34,85 @@ import java.util.List;
  * Created by The eXo Platform SAS Author : Tuan Nguyen
  * tuan08@users.sourceforge.net Oct 13, 2005
  */
-abstract public class BaseOrganizationService implements OrganizationService, Startable, ComponentRequestLifecycle
-{
-   protected UserHandler userDAO_;
+public abstract class BaseOrganizationService implements OrganizationService, Startable, ComponentRequestLifecycle {
+  public static final Log                        LOG        = ExoLogger.getLogger(BaseOrganizationService.class);
 
-   protected UserProfileHandler userProfileDAO_;
+  protected UserHandler                          userDAO_;                                                       // NOSONAR
 
-   protected GroupHandler groupDAO_;
+  protected UserProfileHandler                   userProfileDAO_;                                                // NOSONAR
 
-   protected MembershipHandler membershipDAO_;
+  protected GroupHandler                         groupDAO_;                                                      // NOSONAR
 
-   protected MembershipTypeHandler membershipTypeDAO_;
+  protected MembershipHandler                    membershipDAO_;                                                 // NOSONAR
 
-   protected List<OrganizationServiceInitializer> listeners_ = new ArrayList<OrganizationServiceInitializer>(3);
+  protected MembershipTypeHandler                membershipTypeDAO_;                                             // NOSONAR
 
-   public UserHandler getUserHandler()
-   {
-      return userDAO_;
-   }
+  protected List<OrganizationServiceInitializer> listeners_ = new ArrayList<>();                                 // NOSONAR
 
-   public UserProfileHandler getUserProfileHandler()
-   {
-      return userProfileDAO_;
-   }
+  public UserHandler getUserHandler() {
+    return userDAO_;
+  }
 
-   public GroupHandler getGroupHandler()
-   {
-      return groupDAO_;
-   }
+  public UserProfileHandler getUserProfileHandler() {
+    return userProfileDAO_;
+  }
 
-   public MembershipTypeHandler getMembershipTypeHandler()
-   {
-      return membershipTypeDAO_;
-   }
+  public GroupHandler getGroupHandler() {
+    return groupDAO_;
+  }
 
-   public MembershipHandler getMembershipHandler()
-   {
-      return membershipDAO_;
-   }
+  public MembershipTypeHandler getMembershipTypeHandler() {
+    return membershipTypeDAO_;
+  }
 
-   public void start()
-   {
-      try
-      {
-         RequestLifeCycle.begin(this);
+  public MembershipHandler getMembershipHandler() {
+    return membershipDAO_;
+  }
 
-         for (OrganizationServiceInitializer listener : listeners_)
-         {
-            try
-            {
-               listener.init(this);
-            }
-            catch (Exception ex)
-            {
-               String msg =
-                  "Failed start Organization Service " + getClass().getName()
-                     + ", probably because of configuration error. Error occurs when initialize "
-                     + listener.getClass().getName();
-               throw new RuntimeException(msg, ex);
-            }
-         }
+  @Override
+  public void start() {
+    RequestLifeCycle.begin(this);
+    try {
+      init(OrganizationServiceInitializer.GROUPS_ENTITY_TYPE);
+      init(OrganizationServiceInitializer.ROLES_ENTITY_TYPE);
+      init(OrganizationServiceInitializer.USERS_ENTITY_TYPE);
+    } finally {
+      RequestLifeCycle.end();
+    }
+  }
+
+  public synchronized void addListenerPlugin(ComponentPlugin listener) throws Exception {
+    if (listener instanceof UserEventListener eventListener) {
+      userDAO_.addUserEventListener(eventListener);
+    } else if (listener instanceof GroupEventListener eventListener) {
+      groupDAO_.addGroupEventListener(eventListener);
+    } else if (listener instanceof MembershipTypeEventListener eventListener) {
+      membershipTypeDAO_.addMembershipTypeEventListener(eventListener);
+    } else if (listener instanceof MembershipEventListener eventListener) {
+      membershipDAO_.addMembershipEventListener(eventListener);
+    } else if (listener instanceof UserProfileEventListener eventListener) {
+      userProfileDAO_.addUserProfileEventListener(eventListener);
+    } else if (listener instanceof OrganizationServiceInitializer initializer) {
+      listeners_.add(initializer);
+    }
+  }
+
+  public void startRequest(ExoContainer container) {
+  }
+
+  public void endRequest(ExoContainer container) {
+  }
+
+  private void init(String entityType) {
+    for (OrganizationServiceInitializer listener : listeners_) {
+      try {
+        listener.init(this, entityType);
+      } catch (Exception ex) {
+        LOG.warn("Failed start Organization Service {}, probably because of configuration error. Error occurs when initialize {}",
+                 getClass().getName(),
+                 listener.getClass().getName());
       }
-      finally
-      {
-         RequestLifeCycle.end();
-      }
-   }
+    }
+  }
 
-   public void stop()
-   {
-   }
-
-   synchronized public void addListenerPlugin(ComponentPlugin listener) throws Exception
-   {
-      if (listener instanceof UserEventListener)
-      {
-         userDAO_.addUserEventListener((UserEventListener)listener);
-      }
-      else if (listener instanceof GroupEventListener)
-      {
-         groupDAO_.addGroupEventListener((GroupEventListener)listener);
-      }
-      else if (listener instanceof MembershipTypeEventListener)
-      {
-         membershipTypeDAO_.addMembershipTypeEventListener((MembershipTypeEventListener)listener);
-      }
-      else if (listener instanceof MembershipEventListener)
-      {
-         membershipDAO_.addMembershipEventListener((MembershipEventListener)listener);
-      }
-      else if (listener instanceof UserProfileEventListener)
-      {
-         userProfileDAO_.addUserProfileEventListener((UserProfileEventListener)listener);
-      }
-      else if (listener instanceof OrganizationServiceInitializer)
-      {
-         listeners_.add((OrganizationServiceInitializer)listener);
-      }
-      else
-      {
-         throw new RuntimeException(listener.getClass().getName() + " is an unknown listener type");
-      }
-   }
-
-   /**
-    * {@inheritDoc}
-    */
-   public void startRequest(ExoContainer container)
-   {
-   }
-
-   /**
-    * {@inheritDoc}
-    */
-   public void endRequest(ExoContainer container)
-   {
-   }
 }

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/OrganizationDatabaseInitializer.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/OrganizationDatabaseInitializer.java
@@ -18,6 +18,8 @@
  */
 package org.exoplatform.services.organization;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.commons.utils.PageList;
 import org.exoplatform.container.component.BaseComponentPlugin;
 import org.exoplatform.container.component.ComponentPlugin;
@@ -30,236 +32,197 @@ import java.util.Date;
 import java.util.List;
 
 public class OrganizationDatabaseInitializer extends BaseComponentPlugin implements OrganizationServiceInitializer,
-   ComponentPlugin
-{
+    ComponentPlugin {
 
-   protected static final Log LOG = ExoLogger
-      .getLogger("exo.core.component.organization.api.OrganizationDatabaseInitializer");
+  protected static final Log  LOG                     = ExoLogger
+                                                                 .getLogger("exo.core.component.organization.api.OrganizationDatabaseInitializer");
 
-   private OrganizationConfig config_;
+  private OrganizationConfig  config_;
 
-   protected static final int CHECK_EMPTY = 0, CHECK_ENTRY = 1;
+  protected static final int  CHECK_EMPTY             = 0, CHECK_ENTRY = 1;
 
-   private int checkDatabaseAlgorithm_ = CHECK_EMPTY;
+  private int                 checkDatabaseAlgorithm_ = CHECK_EMPTY;
 
-   private boolean printInfo_;
+  private boolean             printInfo_;
 
-   private boolean updateUsers_;
+  private boolean             updateUsers_;
 
-   public OrganizationDatabaseInitializer(InitParams params) throws Exception
-   {
-      String checkConfig = params.getValueParam("checkDatabaseAlgorithm").getValue();
-      if (checkConfig.trim().equalsIgnoreCase("entry"))
-      {
-         checkDatabaseAlgorithm_ = CHECK_ENTRY;
-      }
-      else
-      {
-         checkDatabaseAlgorithm_ = CHECK_EMPTY;
-      }
-      String printInfoConfig = params.getValueParam("printInformation").getValue();
-      printInfo_ = printInfoConfig.trim().equalsIgnoreCase("true");
-      ValueParam usParam = params.getValueParam("updateUsers");
-      if (usParam != null)
-      {
-         String updateUsersParam = usParam.getValue();
-         updateUsers_ = (updateUsersParam != null && updateUsersParam.trim().equalsIgnoreCase("true"));
-      }
-      config_ = params.getObjectParamValues(OrganizationConfig.class).get(0);
-   }
+  public OrganizationDatabaseInitializer(InitParams params) throws Exception {
+    String checkConfig = params.getValueParam("checkDatabaseAlgorithm").getValue();
+    if (checkConfig.trim().equalsIgnoreCase("entry")) {
+      checkDatabaseAlgorithm_ = CHECK_ENTRY;
+    } else {
+      checkDatabaseAlgorithm_ = CHECK_EMPTY;
+    }
+    String printInfoConfig = params.getValueParam("printInformation").getValue();
+    printInfo_ = printInfoConfig.trim().equalsIgnoreCase("true");
+    ValueParam usParam = params.getValueParam("updateUsers");
+    if (usParam != null) {
+      String updateUsersParam = usParam.getValue();
+      updateUsers_ = (updateUsersParam != null && updateUsersParam.trim().equalsIgnoreCase("true"));
+    }
+    config_ = params.getObjectParamValues(OrganizationConfig.class).get(0);
+  }
 
-   public void init(OrganizationService service) throws Exception
-   {
-      if (checkDatabaseAlgorithm_ == CHECK_EMPTY && checkExistDatabase(service))
-      {
-         return;
-      }
-      String alg = "check empty database";
-      if (checkDatabaseAlgorithm_ == CHECK_ENTRY)
-         alg = "check entry database";
-      printInfo("=======> Initialize the  organization service data  using algorithm " + alg);
+  public void init(OrganizationService service, String entityType) throws Exception {
+    if (checkDatabaseAlgorithm_ == CHECK_EMPTY && checkExistDatabase(service)) {
+      return;
+    }
+    String alg = "check empty database";
+    if (checkDatabaseAlgorithm_ == CHECK_ENTRY)
+      alg = "check entry database";
+    printInfo("=======> Initialize the  organization service data  using algorithm " + alg);
+    if (StringUtils.equals(entityType, GROUPS_ENTITY_TYPE)) {
       createGroups(service);
+    } else if (StringUtils.equals(entityType, ROLES_ENTITY_TYPE)) {
       createMembershipTypes(service);
+    } else if (StringUtils.equals(entityType, USERS_ENTITY_TYPE)) {
       createUsers(service);
-      printInfo("<=======");
-   }
+    }
+    printInfo("<=======");
+  }
 
-   protected boolean checkExistDatabase(OrganizationService service) throws Exception
-   {
-      PageList<?> users = service.getUserHandler().getUserPageList(10);
-      if (users != null && users.getAvailable() > 0)
-         return true;
-      return false;
-   }
+  protected boolean checkExistDatabase(OrganizationService service) throws Exception {
+    PageList<?> users = service.getUserHandler().getUserPageList(10);
+    if (users != null && users.getAvailable() > 0)
+      return true;
+    return false;
+  }
 
-   protected void createGroups(OrganizationService orgService) throws Exception
-   {
-      printInfo("  Init  Group Data");
-      List<?> groups = config_.getGroup();
-      for (int i = 0; i < groups.size(); i++)
-      {
-         OrganizationConfig.Group data = (OrganizationConfig.Group)groups.get(i);
-         String groupId = null;
-         String parentId = data.getParentId();
-         if (parentId == null || parentId.length() == 0)
-            groupId = "/" + data.getName();
-         else
-            groupId = data.getParentId() + "/" + data.getName();
+  protected void createGroups(OrganizationService orgService) throws Exception {
+    printInfo("  Init  Group Data");
+    List<?> groups = config_.getGroup();
+    for (int i = 0; i < groups.size(); i++) {
+      OrganizationConfig.Group data = (OrganizationConfig.Group) groups.get(i);
+      String groupId = null;
+      String parentId = data.getParentId();
+      if (parentId == null || parentId.length() == 0)
+        groupId = "/" + data.getName();
+      else
+        groupId = data.getParentId() + "/" + data.getName();
 
-         if (orgService.getGroupHandler().findGroupById(groupId) == null)
-         {
-            Group group = orgService.getGroupHandler().createGroupInstance();
-            group.setGroupName(data.getName());
-            group.setDescription(data.getDescription());
-            group.setLabel(data.getLabel());
-            if (parentId == null || parentId.length() == 0)
-            {
-               orgService.getGroupHandler().addChild(null, group, true);
-            }
-            else
-            {
-               Group parentGroup = orgService.getGroupHandler().findGroupById(parentId);
-               orgService.getGroupHandler().addChild(parentGroup, group, true);
-            }
-            printInfo("    Create Group " + groupId);
-         }
-         else
-         {
-            printInfo("    Group " + groupId + " already exists, ignoring the entry");
-         }
+      if (orgService.getGroupHandler().findGroupById(groupId) == null) {
+        Group group = orgService.getGroupHandler().createGroupInstance();
+        group.setGroupName(data.getName());
+        group.setDescription(data.getDescription());
+        group.setLabel(data.getLabel());
+        if (parentId == null || parentId.length() == 0) {
+          orgService.getGroupHandler().addChild(null, group, true);
+        } else {
+          Group parentGroup = orgService.getGroupHandler().findGroupById(parentId);
+          orgService.getGroupHandler().addChild(parentGroup, group, true);
+        }
+        printInfo("    Create Group " + groupId);
+      } else {
+        printInfo("    Group " + groupId + " already exists, ignoring the entry");
       }
-   }
+    }
+  }
 
-   protected void createMembershipTypes(OrganizationService service) throws Exception
-   {
-      printInfo("  Init  Membership Type  Data");
-      List<?> types = config_.getMembershipType();
-      for (int i = 0; i < types.size(); i++)
-      {
-         OrganizationConfig.MembershipType data = (OrganizationConfig.MembershipType)types.get(i);
-         MembershipType membershipType= service.getMembershipTypeHandler().findMembershipType(data.getType());
-         if (membershipType == null)
-         {
-            MembershipType type = service.getMembershipTypeHandler().createMembershipTypeInstance();
-            type.setName(data.getType());
-            type.setDescription(data.getDescription());
-            service.getMembershipTypeHandler().createMembershipType(type, true);
-            printInfo("    Created Membership Type " + data.getType());
-         }
-         else if (membershipType.getName().equals(MembershipTypeHandler.ANY_MEMBERSHIP_TYPE))
-         {
+  protected void createMembershipTypes(OrganizationService service) throws Exception {
+    printInfo("  Init  Membership Type  Data");
+    List<?> types = config_.getMembershipType();
+    for (int i = 0; i < types.size(); i++) {
+      OrganizationConfig.MembershipType data = (OrganizationConfig.MembershipType) types.get(i);
+      MembershipType membershipType = service.getMembershipTypeHandler().findMembershipType(data.getType());
+      if (membershipType == null) {
+        MembershipType type = service.getMembershipTypeHandler().createMembershipTypeInstance();
+        type.setName(data.getType());
+        type.setDescription(data.getDescription());
+        service.getMembershipTypeHandler().createMembershipType(type, true);
+        printInfo("    Created Membership Type " + data.getType());
+      } else if (membershipType.getName().equals(MembershipTypeHandler.ANY_MEMBERSHIP_TYPE)) {
 
-            membershipType.setDescription(data.getDescription());
+        membershipType.setDescription(data.getDescription());
 
-         }
-         else
-         {
-            printInfo("    Membership Type " + data.getType() + " already exists, ignoring the entry");
-         }
+      } else {
+        printInfo("    Membership Type " + data.getType() + " already exists, ignoring the entry");
       }
-   }
+    }
+  }
 
-   protected void createUsers(OrganizationService service) throws Exception
-   {
-      printInfo("  Init  User  Data");
-      List<?> users = config_.getUser();
-      MembershipHandler mhandler = service.getMembershipHandler();
-      for (int i = 0; i < users.size(); i++)
-      {
-         OrganizationConfig.User data = (OrganizationConfig.User)users.get(i);
-         UserHandler handler = service.getUserHandler();
-         User user = handler.findUserByName(data.getUserName(), UserStatus.ANY);
-         if (user == null)
-         {
-            user = handler.createUserInstance(data.getUserName());
-            user.setPassword(data.getPassword());
-            user.setFirstName(data.getFirstName());
-            user.setLastName(data.getLastName());
-            user.setEmail(data.getEmail());
-            user.setDisplayName(data.getDisplayName());
-            handler.createUser(user, true);
-            if (!data.isEnabled())
-            {
-                handler.setEnabled(user.getUserName(), false, true);    
-            }
-            printInfo("    Created user " + data.getUserName());
-         } 
-         else if (updateUsers_) 
-         {
-            if (!user.isEnabled())
-            {
-               handler.setEnabled(user.getUserName(), true, true);
-            }
-            handler.saveUser(user, true);
-            if (!data.isEnabled())
-            {
-               handler.setEnabled(user.getUserName(), false, true);
-            }
-            printInfo("    User " + data.getUserName() + " updated");
-         }
-         else
-         {
-            printInfo("    User " + data.getUserName() + " already exists, ignoring the entry");
-         }
-
-         String groups = data.getGroups();
-         String[] entry = groups.split(",");
-         for (int j = 0; j < entry.length; j++)
-         {
-            String[] temp = entry[j].trim().split(":");
-            String membership = temp[0];
-            String groupId = temp[1];
-            if (mhandler.findMembershipByUserGroupAndType(data.getUserName(), groupId, membership) == null)
-            {
-               Group group = service.getGroupHandler().findGroupById(groupId);
-               MembershipType mt = service.getMembershipTypeHandler().createMembershipTypeInstance();
-               mt.setName(membership);
-               mhandler.linkMembership(user, group, mt, true);
-               printInfo("    Created membership " + data.getUserName() + ", " + groupId + ", " + membership);
-            }
-            else
-            {
-               printInfo("    Ignored membership " + data.getUserName() + ", " + groupId + ", " + membership);
-            }
-         }
+  protected void createUsers(OrganizationService service) throws Exception {
+    printInfo("  Init  User  Data");
+    List<?> users = config_.getUser();
+    MembershipHandler mhandler = service.getMembershipHandler();
+    for (int i = 0; i < users.size(); i++) {
+      OrganizationConfig.User data = (OrganizationConfig.User) users.get(i);
+      UserHandler handler = service.getUserHandler();
+      User user = handler.findUserByName(data.getUserName(), UserStatus.ANY);
+      if (user == null) {
+        user = handler.createUserInstance(data.getUserName());
+        user.setPassword(data.getPassword());
+        user.setFirstName(data.getFirstName());
+        user.setLastName(data.getLastName());
+        user.setEmail(data.getEmail());
+        user.setDisplayName(data.getDisplayName());
+        handler.createUser(user, true);
+        if (!data.isEnabled()) {
+          handler.setEnabled(user.getUserName(), false, true);
+        }
+        printInfo("    Created user " + data.getUserName());
+      } else if (updateUsers_) {
+        if (!user.isEnabled()) {
+          handler.setEnabled(user.getUserName(), true, true);
+        }
+        handler.saveUser(user, true);
+        if (!data.isEnabled()) {
+          handler.setEnabled(user.getUserName(), false, true);
+        }
+        printInfo("    User " + data.getUserName() + " updated");
+      } else {
+        printInfo("    User " + data.getUserName() + " already exists, ignoring the entry");
       }
-   }
 
-   protected void printInfo(String message)
-   {
-      if (printInfo_)
-         LOG.info(message);
-   }
+      String groups = data.getGroups();
+      String[] entry = groups.split(",");
+      for (int j = 0; j < entry.length; j++) {
+        String[] temp = entry[j].trim().split(":");
+        String membership = temp[0];
+        String groupId = temp[1];
+        if (mhandler.findMembershipByUserGroupAndType(data.getUserName(), groupId, membership) == null) {
+          Group group = service.getGroupHandler().findGroupById(groupId);
+          MembershipType mt = service.getMembershipTypeHandler().createMembershipTypeInstance();
+          mt.setName(membership);
+          mhandler.linkMembership(user, group, mt, true);
+          printInfo("    Created membership " + data.getUserName() + ", " + groupId + ", " + membership);
+        } else {
+          printInfo("    Ignored membership " + data.getUserName() + ", " + groupId + ", " + membership);
+        }
+      }
+    }
+  }
 
-   /**
-    * @return the config
-    */
-   protected OrganizationConfig getConfig()
-   {
-      return config_;
-   }
+  protected void printInfo(String message) {
+    if (printInfo_)
+      LOG.info(message);
+  }
 
-   /**
-    * @return the checkDatabaseAlgorithm
-    */
-   protected int getCheckDatabaseAlgorithm()
-   {
-      return checkDatabaseAlgorithm_;
-   }
+  /**
+   * @return the config
+   */
+  protected OrganizationConfig getConfig() {
+    return config_;
+  }
 
-   /**
-    * @return the printInfo
-    */
-   protected boolean isPrintInfo()
-   {
-      return printInfo_;
-   }
+  /**
+   * @return the checkDatabaseAlgorithm
+   */
+  protected int getCheckDatabaseAlgorithm() {
+    return checkDatabaseAlgorithm_;
+  }
 
-   /**
-    * @return the updateUsers
-    */
-   public boolean isUpdateUsers()
-   {
-      return updateUsers_;
-   }
+  /**
+   * @return the printInfo
+   */
+  protected boolean isPrintInfo() {
+    return printInfo_;
+  }
+
+  /**
+   * @return the updateUsers
+   */
+  public boolean isUpdateUsers() {
+    return updateUsers_;
+  }
 }

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/OrganizationServiceInitializer.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/OrganizationServiceInitializer.java
@@ -51,10 +51,18 @@ package org.exoplatform.services.organization;
  */
 public interface OrganizationServiceInitializer
 {
+
+  static final String USERS_ENTITY_TYPE  = "users";
+
+  static final String GROUPS_ENTITY_TYPE = "groups";
+
+  static final String ROLES_ENTITY_TYPE  = "membershipTypes";
+
    /**
     *  The Organization Service Initializer to create users, groups and membership types.
     *
     * @param service OrganizationService is the service that allows to access the Organization model.
+    * @param entityType Entity Type to consider for importing
     */
-   public void init(OrganizationService service) throws Exception;
+   public void init(OrganizationService service, String entityType) throws Exception;
 }


### PR DESCRIPTION
Prior to this change, the import of IDM data is made listener by listener. Each listener ca bring definition of one of multiple items of three types '`Group`', '`Role`' or '`User + Memberships`'. When a listener defines a use which is member of a group defined in another listener, the import fails. Thus this change will proceed importing by types instead f by listener.