### PR TITLE
feat: Add Caches to IdentityRegistry and ConversationRegistry - MEED-9593 - Meeds-io/meeds#3472

### DIFF
--- a/exo.core.component.security.core/pom.xml
+++ b/exo.core.component.security.core/pom.xml
@@ -47,6 +47,10 @@
       </dependency>
       <dependency>
          <groupId>io.meeds.kernel</groupId>
+         <artifactId>exo.kernel.component.cache</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.meeds.kernel</groupId>
          <artifactId>exo.kernel.commons.test</artifactId>
          <scope>test</scope>
       </dependency>

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationRegistry.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationRegistry.java
@@ -18,227 +18,177 @@
  */
 package org.exoplatform.services.security;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.container.spi.DefinitionByType;
-import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.container.xml.ValueParam;
+
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 /**
  * In-memory registry of user's sessions
  */
-@DefinitionByType
-public final class ConversationRegistry
-{
+public final class ConversationRegistry {
 
-   /**
-    * "concurrency-level".
-    */
-   public static final String INIT_PARAM_CONCURRENCY_LEVEL = "concurrency-level";
+  private static final String                         CACHE_NAME      = "portal.ConversationRegistry";
 
-   /**
-    * Logger.
-    */
-   private static final Log LOG = ExoLogger.getLogger("exo.core.component.security.core.ConversationRegistry");
+  private static final String                         STATE_KEYS_NAME = "portal.ConversationRegistryStates";
 
-   /**
-    * Default concurrency level.
-    */
-   private static final int DEFAULT_CONCURRENCY_LEVEL = 16;
+  private static final Log                            LOG             = ExoLogger.getLogger(ConversationRegistry.class);
 
-   /**
-    * Storage for ConversationStates.
-    */
-   private final ConcurrentHashMap<StateKey, ConversationState> states;
+  private final ExoCache<StateKey, ConversationState> statesCache;
 
-   /**
-    * @see {@link IdentityRegistry}
-    */
-   private final IdentityRegistry identityRegistry;
+  private final ExoCache<String, Set<StateKey>>       stateKeysCache;
 
-   /**
-    * @see {@link ListenerService}
-    */
-   private final ListenerService listenerService;
+  private final IdentityRegistry                      identityRegistry;
 
-   /**
-    * @param params
-    * @param identityRegistry {@link IdentityRegistry}
-    * @param listenerService {@link ListenerService}
-    */
-   public ConversationRegistry(InitParams params, IdentityRegistry identityRegistry, ListenerService listenerService)
-   {
-      this(parse(params), identityRegistry, listenerService);
-   }
+  private final ListenerService                       listenerService;
 
-   private static int parse(InitParams ip)
-   {
-      try
-      {
-         if (ip != null)
-         {
-            ValueParam concurrencyLevel = ip.getValueParam(INIT_PARAM_CONCURRENCY_LEVEL);
+  public ConversationRegistry(IdentityRegistry identityRegistry,
+                              ListenerService listenerService,
+                              CacheService cacheService) {
+    this.statesCache = cacheService.getCacheInstance(CACHE_NAME);
+    this.stateKeysCache = cacheService.getCacheInstance(STATE_KEYS_NAME);
+    this.identityRegistry = identityRegistry;
+    this.listenerService = listenerService;
+  }
 
-            if (concurrencyLevel != null)
-            {
-               return Integer.valueOf(concurrencyLevel.getValue());
-            }
-         }
+  /**
+   * Get ConversationState with specified key.
+   * 
+   * @param key the key.
+   * @return ConversationState.
+   */
+  public ConversationState getState(StateKey key) {
+    return statesCache.get(key);
+  }
 
-         return DEFAULT_CONCURRENCY_LEVEL;
+  /**
+   * Sets the user's session to the registry and broadcasts ADD_SESSION_EVENT
+   * message to interested listeners.
+   * 
+   * @param key the session identifier.
+   * @param state the conversation state.
+   */
+  public void register(StateKey key, ConversationState state) {
+    String userId = state.getIdentity().getUserId();
+    // We will broadcast login event if :
+    // 1- session is not already registered -> session ID is not in the states
+    // map keys
+    // 2- user is not already logged-in (there is no registered state with the
+    // same userID)
+    boolean broadcast = statesCache.get(key) == null && StringUtils.isNotBlank(userId) && getStateKeys(userId).isEmpty();
+    statesCache.put(key, state);
+    addStateKey(userId, key);
+    if (broadcast) { // NOSONAR
+      try {
+        listenerService.broadcast("exo.core.security.ConversationRegistry.register", this, state);
+      } catch (Exception e) {
+        LOG.error("Broadcast message filed ", e);
       }
-      catch (NumberFormatException e)
-      {
-         LOG.error("Can't parse parameter " + INIT_PARAM_CONCURRENCY_LEVEL, e);
-         return DEFAULT_CONCURRENCY_LEVEL;
-      }
-   }
+    }
+  }
 
-   /**
-    * @param concurrencyLevel the estimated number of concurrently updating
-    *          threads. The implementation performs internal sizing
-    * @param identityRegistry @see {@link IdentityRegistry}
-    * @param listenerService @see {@link ListenerService}
-    */
-   private ConversationRegistry(int concurrencyLevel, IdentityRegistry identityRegistry, ListenerService listenerService)
-   {
-      this.states = new ConcurrentHashMap<StateKey, ConversationState>(concurrencyLevel, 0.75f, concurrencyLevel);
-      this.identityRegistry = identityRegistry;
-      this.listenerService = listenerService;
-   }
+  /**
+   * Remove ConversationStae with specified key. If there is no more
+   * ConversationState for user then remove Identity from IdentityRegistry.
+   * 
+   * @param key the key.
+   * @return removed ConversationState or null.
+   */
+  public ConversationState unregister(StateKey key) {
+    return unregister(key, true);
+  }
 
-   /**
-    * Get ConversationState with specified key.
-    * 
-    * @param key the key.
-    * @return ConversationState.
-    */
-   public ConversationState getState(StateKey key)
-   {
-      return states.get(key);
-   }
-
-   /**
-    * Sets the user's session to the registry and broadcasts ADD_SESSION_EVENT
-    * message to interested listeners.
-    * 
-    * @param key the session identifier.
-    * @param state the conversation state.
-    */
-   public void register(StateKey key, ConversationState state)
-   {
+  /**
+   * Remove ConversationState with specified key. If there is no more
+   * ConversationState for user and <code>unregisterIdentity</code> is true then
+   * remove Identity from IdentityRegistry.
+   * 
+   * @param key the key.
+   * @param unregisterIdentity if true and no more ConversationStates for user
+   *          then unregister Identity
+   * @return removed ConversationState or null.
+   */
+  public ConversationState unregister(StateKey key, boolean unregisterIdentity) {
+    ConversationState state = statesCache.remove(key);
+    if (state != null) {
       String userId = state.getIdentity().getUserId();
-      // We will broadcast login event if :
-      // 1- session is not already registered -> session ID is not in the states map keys
-      // 2- user is not already logged-in (there is no registered state with the same userID)
-      boolean broadcast = states.get(key) == null && StringUtils.isNotBlank(userId) && getStateKeys(userId).isEmpty();
-      states.put(key, state);
-      if (broadcast) {
-         try {
-            listenerService.broadcast("exo.core.security.ConversationRegistry.register", this, state);
-         } catch (Exception e) {
-            LOG.error("Broadcast message filed ", e);
-         }
+      removeStateKey(userId, key);
+      if (unregisterIdentity && CollectionUtils.isEmpty(stateKeysCache.get(userId))) {
+        identityRegistry.unregister(userId);
       }
-   }
-
-   /**
-    * Remove ConversationStae with specified key. If there is no more
-    * ConversationState for user then remove Identity from IdentityRegistry.
-    * 
-    * @param key the key.
-    * @return removed ConversationState or null.
-    */
-   public ConversationState unregister(StateKey key)
-   {
-      return unregister(key, true);
-   }
-
-   /**
-    * Remove ConversationState with specified key. If there is no more
-    * ConversationState for user and <code>unregisterIdentity</code> is true then
-    * remove Identity from IdentityRegistry.
-    * 
-    * @param key the key.
-    * @param unregisterIdentity if true and no more ConversationStates for user
-    *          then unregister Identity
-    * @return removed ConversationState or null.
-    */
-   public ConversationState unregister(StateKey key, boolean unregisterIdentity)
-   {
-      ConversationState state = states.remove(key);
-
-      if (state == null)
-         return null;
-
-      String userId = state.getIdentity().getUserId();
-
-      List<StateKey> keys = getStateKeys(userId);
-      if (unregisterIdentity && keys.size() == 0)
-      {
-         identityRegistry.unregister(userId);
+      try {
+        listenerService.broadcast("exo.core.security.ConversationRegistry.unregister", this, state);
+      } catch (Exception e) {
+        LOG.error("Broadcast message filed ", e);
       }
+    }
+    return state;
+  }
 
-      try
-      {
-         listenerService.broadcast("exo.core.security.ConversationRegistry.unregister", this, state);
+  /**
+   * Unregister all conversation states for user with specified Id.
+   * 
+   * @param userId user Id
+   * @return set of unregistered conversation states
+   */
+  public List<ConversationState> unregisterByUserId(String userId) {
+    List<ConversationState> states = new ArrayList<>();
+    Set<StateKey> stateKeys = stateKeysCache.get(userId);
+    if (stateKeys != null) {
+      stateKeys = new HashSet<>(stateKeys); // Avoid ConcurrentModificationException
+      for (StateKey key : stateKeys) {
+        ConversationState state = unregister(key, false);
+        if (state != null) {
+          states.add(state);
+        }
       }
-      catch (Exception e)
-      {
-         LOG.error("Broadcast message filed ", e);
+    }
+    return states;
+  }
+
+  /**
+   * @param userId the user's identifier.
+   * @return list of users ConversationState.
+   */
+  public List<StateKey> getStateKeys(String userId) {
+    return stateKeysCache.get(userId) == null ? Collections.emptyList(): new ArrayList<>(stateKeysCache.get(userId));
+  }
+
+  /**
+   * Remove all ConversationStates.
+   */
+  void clear() {
+    statesCache.clearCache();
+    stateKeysCache.clearCache();
+  }
+
+  private void removeStateKey(String userId, StateKey key) {
+    Set<StateKey> stateKeys = stateKeysCache.get(userId);
+    if (stateKeys != null) {
+      stateKeys.remove(key);
+      if (stateKeys.isEmpty()) {
+        stateKeysCache.remove(userId);
       }
+    }
+  }
 
-      return state;
-   }
-
-   /**
-    * Unregister all conversation states for user with specified Id.
-    * 
-    * @param userId user Id
-    * @return set of unregistered conversation states
-    */
-   public List<ConversationState> unregisterByUserId(String userId)
-   {
-      List<ConversationState> states = new ArrayList<ConversationState>();
-      for (StateKey key : getStateKeys(userId))
-      {
-         ConversationState state = unregister(key, false);
-         if (state != null)
-         {
-            states.add(state);
-         }
-      }
-      return states;
-   }
-
-   /**
-    * @param userId the user's identifier.
-    * @return list of users ConversationState.
-    */
-   public List<StateKey> getStateKeys(String userId)
-   {
-      ArrayList<StateKey> s = new ArrayList<StateKey>();
-      for (Map.Entry<StateKey, ConversationState> a : states.entrySet())
-      {
-         if (a.getValue().getIdentity().getUserId().equals(userId))
-            s.add(a.getKey());
-      }
-      return s;
-   }
-
-   /**
-    * Remove all ConversationStates.
-    */
-   void clear()
-   {
-      states.clear();
-   }
+  private void addStateKey(String userId, StateKey key) {
+    Set<StateKey> states = stateKeysCache.get(userId);
+    if (states == null) {
+      states = Collections.synchronizedSet(new HashSet<>());
+    }
+    states.add(key);
+    stateKeysCache.put(userId, states);
+  }
 
 }

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationState.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/ConversationState.java
@@ -23,6 +23,7 @@ import org.exoplatform.container.component.ThreadContextHolder;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -39,7 +40,7 @@ public class ConversationState implements ThreadContextHolder
    /**
     * ThreadLocal keeper for ConversationState.
     */
-   private static ThreadLocal<ConversationState> current = new ThreadLocal<ConversationState>();
+   private static ThreadLocal<ConversationState> current = new ThreadLocal<>();
 
    /**
     * See {@link Identity}.
@@ -54,7 +55,7 @@ public class ConversationState implements ThreadContextHolder
    public ConversationState(Identity identity)
    {
       this.identity = identity;
-      this.attributes = new HashMap<String, Object>();
+      this.attributes = new HashMap<>();
    }
 
    /**
@@ -72,7 +73,11 @@ public class ConversationState implements ThreadContextHolder
     */
    public static void setCurrent(ConversationState state)
    {
-      current.set(state);
+      if (state == null) {
+        current.remove();
+      } else {
+        current.set(state);
+      }
    }
 
    /**
@@ -130,5 +135,29 @@ public class ConversationState implements ThreadContextHolder
    {
       return new ThreadContext(current);
    }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(attributes, identity);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj == null) {
+      return false;
+    } else if (getClass() != obj.getClass()) {
+      return false;
+    } else {
+      ConversationState other = (ConversationState) obj;
+      return Objects.equals(attributes, other.attributes) && Objects.equals(identity, other.identity);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "ConversationState [identity=" + identity + ", attributes=" + attributes + "]";
+  }
 
 }

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/Identity.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/Identity.java
@@ -20,6 +20,7 @@ package org.exoplatform.services.security;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.security.auth.Subject;
@@ -60,7 +61,7 @@ public class Identity
     */
    public Identity(String userId)
    {
-      this(userId, new HashSet<MembershipEntry>(), new HashSet<String>());
+      this(userId, new HashSet<>(), new HashSet<>());
    }
 
    /**
@@ -69,7 +70,7 @@ public class Identity
     */
    public Identity(String userId, Collection<MembershipEntry> memberships)
    {
-      this(userId, memberships, new HashSet<String>());
+      this(userId, memberships, new HashSet<>());
    }
 
    /**
@@ -129,7 +130,7 @@ public class Identity
     */
    public Set<String> getGroups()
    {
-      Set<String> groups = new HashSet<String>();
+      Set<String> groups = new HashSet<>();
       for (MembershipEntry m : memberships)
       {
          groups.add(m.getGroup());
@@ -204,4 +205,31 @@ public class Identity
    {
       return memberships.contains(checkMe);
    }
+
+   @Override
+   public int hashCode() {
+     return Objects.hash(memberships, roles, subject, userId);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+     if (this == obj) {
+       return true;
+     } else if (obj == null) {
+       return false;
+     } else if (getClass() != obj.getClass()) {
+       return false;
+     } else {
+       Identity other = (Identity) obj;
+       return Objects.equals(memberships, other.memberships) && Objects.equals(roles, other.roles)
+              && Objects.equals(subject, other.subject)
+              && Objects.equals(userId, other.userId);
+     }
+   }
+
+   @Override
+   public String toString() {
+     return "Identity [userId=" + userId + ", memberships=" + memberships + ", roles=" + roles + "]";
+   }
+
 }

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/IdentityRegistry.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/IdentityRegistry.java
@@ -18,115 +18,52 @@
  */
 package org.exoplatform.services.security;
 
-import org.exoplatform.container.spi.DefinitionByType;
-import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.container.xml.ValueParam;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
 
-import java.util.concurrent.ConcurrentHashMap;
+public class IdentityRegistry {
 
-@DefinitionByType
-public class IdentityRegistry
-{
+  private static final String              CACHE_NAME = "portal.IdentityRegistry";
 
-   /**
-    * "concurrency-level".
-    */
-   public static final String INIT_PARAM_CONCURRENCY_LEVEL = "concurrency-level";
+  private final ExoCache<String, Identity> identitiesCache;
 
-   /**
-    * Logger.
-    */
-   private static final Log LOG = ExoLogger.getLogger("exo.core.component.security.core.IdentityRegistry");
+  public IdentityRegistry(CacheService cacheService) {
+    identitiesCache = cacheService.getCacheInstance(CACHE_NAME);
+  }
 
-   /**
-    * Default concurrency level.
-    */
-   private static final int DEFAULT_CONCURRENCY_LEVEL = 16;
+  /**
+   * Get identity for supplied user ID.
+   * 
+   * @param userId user ID
+   * @return identity or null if not found
+   */
+  public Identity getIdentity(String userId) {
+    return identitiesCache.get(userId);
+  }
 
-   /**
-    * Identities.
-    */
-   private final ConcurrentHashMap<String, Identity> identities;
+  /**
+   * Register new identity in registry.
+   * 
+   * @param identity {@link Identity}
+   */
+  public void register(Identity identity) {
+    this.identitiesCache.put(identity.getUserId(), identity);
+  }
 
-   public IdentityRegistry(InitParams params)
-   {
-      this(parseConcurrencyLevel(params));
-   }
+  /**
+   * Remove identity with supplied user ID.
+   * 
+   * @param userId user ID
+   */
+  public void unregister(String userId) {
+    this.identitiesCache.remove(userId);
+  }
 
-   /**
-    * Try to parse concurrency level attribute from init parameters.
-    * 
-    * @param params See {@link InitParams}
-    * @return parsed parameter or default if parameter not set or can't be parsed
-    */
-   private static int parseConcurrencyLevel(InitParams params)
-   {
-      try
-      {
-         if (params != null)
-         {
-            ValueParam concurrencyLevel = params.getValueParam(INIT_PARAM_CONCURRENCY_LEVEL);
-
-            if (concurrencyLevel != null)
-            {
-               return Integer.valueOf(concurrencyLevel.getValue());
-            }
-         }
-
-         return DEFAULT_CONCURRENCY_LEVEL;
-      }
-      catch (NumberFormatException e)
-      {
-         LOG.error("Can't parse parameter " + INIT_PARAM_CONCURRENCY_LEVEL, e);
-         return DEFAULT_CONCURRENCY_LEVEL;
-      }
-   }
-
-   /**
-    * Create identity registry.
-    * @param concurrencyLevel concurrency level for ConcurrentHashMap 
-    */
-   private IdentityRegistry(int concurrencyLevel)
-   {
-      identities = new ConcurrentHashMap<String, Identity>(concurrencyLevel, 0.75f, concurrencyLevel);
-   }
-
-   /**
-    * Get identity for supplied user ID.
-    * @param userId user ID
-    * @return identity or null if not found
-    */
-   public Identity getIdentity(String userId)
-   {
-      return identities.get(userId);
-   }
-
-   /**
-    * Register new identity in registry.
-    * @param identity {@link Identity}
-    */
-   public void register(Identity identity)
-   {
-      this.identities.put(identity.getUserId(), identity);
-   }
-
-   /**
-    * Remove identity with supplied user ID. 
-    * @param userId user ID
-    */
-   public void unregister(String userId)
-   {
-      this.identities.remove(userId);
-   }
-
-   /**
-    * Remove all identities.
-    */
-   void clear()
-   {
-      identities.clear();
-   }
+  /**
+   * Remove all identities.
+   */
+  void clear() {
+    identitiesCache.clearCache();
+  }
 
 }

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/MembershipEntry.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/MembershipEntry.java
@@ -126,4 +126,5 @@ public final class MembershipEntry
    {
       return getMembershipType() + ":" + getGroup();
    }
+   
 }

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/StateKey.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/StateKey.java
@@ -18,7 +18,8 @@
  */
 package org.exoplatform.services.security;
 
-public interface StateKey
-{
+import java.io.Serializable;
+
+public interface StateKey extends Serializable {
 
 }

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/web/HttpSessionStateKey.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/web/HttpSessionStateKey.java
@@ -22,39 +22,37 @@ import org.exoplatform.services.security.StateKey;
 
 import jakarta.servlet.http.HttpSession;
 
-public final class HttpSessionStateKey implements StateKey
-{
+public final class HttpSessionStateKey implements StateKey {
 
-   /**
-    * HTTP session ID. 
-    */
-   private final String sessionId;
+  private static final long serialVersionUID = 3009905438380354994L;
 
-   public HttpSessionStateKey(HttpSession httpSession)
-   {
-      this.sessionId = httpSession.getId();
-   }
+  /**
+   * HTTP session ID.
+   */
+  private final String      sessionId;
 
-   /**
-    * {@inheritDoc}
-    */
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      return sessionId.equals(((HttpSessionStateKey)obj).sessionId);
-   }
+  public HttpSessionStateKey(HttpSession httpSession) {
+    this.sessionId = httpSession.getId();
+  }
 
-   /**
-    * {@inheritDoc}
-    */
-   @Override
-   public int hashCode()
-   {
-      return sessionId.hashCode();
-   }
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    } else if (getClass() != obj.getClass()) {
+      return false;
+    } else {
+      return sessionId.equals(((HttpSessionStateKey) obj).sessionId);
+    }
+  }
 
+  @Override
+  public int hashCode() {
+    return sessionId.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("HTTP Session %s", sessionId);
+  }
 }

--- a/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/web/SetCurrentIdentityFilter.java
+++ b/exo.core.component.security.core/src/main/java/org/exoplatform/services/security/web/SetCurrentIdentityFilter.java
@@ -18,6 +18,8 @@
  */
 package org.exoplatform.services.security.web;
 
+import java.io.IOException;
+
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.web.AbstractFilter;
@@ -31,177 +33,128 @@ import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.security.StateKey;
 
-import java.io.IOException;
-
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
-public class SetCurrentIdentityFilter extends AbstractFilter
-{
+public class SetCurrentIdentityFilter extends AbstractFilter {
 
-   private boolean restoreIdentity;
+  private static final Log     LOG = ExoLogger.getLogger("exo.core.component.security.core.SetCurrentIdentityFilter");
 
-   /**
-    * Logger.
-    */
-   private static final Log LOG = ExoLogger.getLogger("exo.core.component.security.core.SetCurrentIdentityFilter");
+  private ConversationRegistry conversationRegistry;
 
-   /**
-    * {@inheritDoc}
-    */
-   @Override
-   protected void afterInit(FilterConfig config) throws ServletException
-   {
-      super.afterInit(config);
-      restoreIdentity = Boolean.parseBoolean(config.getInitParameter("restoreIdentity"));
-   }
+  private IdentityRegistry     identityRegistry;
 
-   /**
-    * Set current {@link ConversationState}, if it is not registered yet then
-    * create new one and register in {@link ConversationRegistry}. {@inheritDoc}
-    */
-   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
-      ServletException
-   {
+  /**
+   * Set current {@link ConversationState}, if it is not registered yet then
+   * create new one and register in {@link ConversationRegistry}. {@inheritDoc}
+   */
+  public void doFilter(ServletRequest request,
+                       ServletResponse response,
+                       FilterChain chain) throws IOException,
+                                          ServletException {
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    ExoContainer container = getContainer();
 
-      HttpServletRequest httpRequest = (HttpServletRequest)request;
-      ExoContainer container = getContainer();
-
-      try
-      {
-         ExoContainerContext.setCurrentContainer(container);
-         ConversationState state = getCurrentState(container, httpRequest);
-         ConversationState.setCurrent(state);
-         chain.doFilter(request, response);
+    try {
+      ExoContainerContext.setCurrentContainer(container);
+      ConversationState state = getCurrentState(container, httpRequest);
+      ConversationState.setCurrent(state);
+      chain.doFilter(request, response);
+    } finally {
+      try {
+        ConversationState.setCurrent(null);
+      } catch (Exception e) {
+        LOG.warn("An error occured while cleaning the ThreadLocal", e);
       }
-      finally
-      {
-         try
-         {
-            ConversationState.setCurrent(null);
-         }
-         catch (Exception e)
-         {
-            LOG.warn("An error occured while cleaning the ThreadLocal", e);
-         }
-         try
-         {
-            ExoContainerContext.setCurrentContainer(null);
-         }
-         catch (Exception e)
-         {
-            LOG.warn("An error occured while cleaning the ThreadLocal", e);
-         }
+      try {
+        ExoContainerContext.setCurrentContainer(null);
+      } catch (Exception e) {
+        LOG.warn("An error occured while cleaning the ThreadLocal", e);
       }
-   }
+    }
+  }
 
-   /**
-    * Gives the current state
-    */
-   private ConversationState getCurrentState(ExoContainer container, HttpServletRequest httpRequest)
-   {
-      ConversationRegistry conversationRegistry =
-         (ConversationRegistry)container.getComponentInstanceOfType(ConversationRegistry.class);
+  /**
+   * Gives the current state
+   */
+  private ConversationState getCurrentState(ExoContainer container, HttpServletRequest httpRequest) {
+    ConversationState state = null;
+    String userId = httpRequest.getRemoteUser();
 
-      IdentityRegistry identityRegistry =
-         (IdentityRegistry)container.getComponentInstanceOfType(IdentityRegistry.class);
+    // only if user authenticated, otherwise there is no reason to do anythings
+    if (userId != null) {
+      HttpSession httpSession = httpRequest.getSession();
+      StateKey stateKey = new HttpSessionStateKey(httpSession);
 
-      ConversationState state = null;
-      String userId = httpRequest.getRemoteUser();
-
-      // only if user authenticated, otherwise there is no reason to do anythings
-      if (userId != null)
-      {
-         HttpSession httpSession = httpRequest.getSession();
-         StateKey stateKey = new HttpSessionStateKey(httpSession);
-
-         if (LOG.isDebugEnabled())
-         {
-            LOG.debug("Looking for Conversation State " + httpSession.getId());
-         }
-
-         state = conversationRegistry.getState(stateKey);
-
-         if(state != null && !userId.equals(state.getIdentity().getUserId())){
-             state = null;
-             conversationRegistry.unregister(stateKey, false);
-             LOG.debug("The current conversation state with the session ID " + httpSession.getId() + " does not belong to the user " + userId + ". The conversation state registry will be updated.");
-         }
-
-         if (state == null)
-         {
-            if (LOG.isDebugEnabled())
-            {
-               LOG.debug("Conversation State not found, try create new one.");
-            }
-
-            Identity identity = identityRegistry.getIdentity(userId);
-            if (identity != null)
-            {
-               state = new ConversationState(identity);
-               // Keep subject as attribute in ConversationState.
-               state.setAttribute(ConversationState.SUBJECT, identity.getSubject());
-            }
-            else
-            {
-               if (restoreIdentity)
-               {
-                  if (LOG.isDebugEnabled())
-                  {
-                     LOG.debug("Not found identity for " + userId + " try to restore it. ");
-                  }
-
-                  Authenticator authenticator =
-                     (Authenticator)container.getComponentInstanceOfType(Authenticator.class);
-                  try
-                  {
-                     identity = authenticator.createIdentity(userId);
-                     identityRegistry.register(identity);
-                  }
-                  catch (Exception e)
-                  {
-                     LOG.error("Unable restore identity. " + e.getMessage(), e);
-                  }
-
-                  if (identity != null)
-                  {
-                     state = new ConversationState(identity);
-                  }
-               }
-               else
-               {
-                  LOG.error("Not found identity in IdentityRegistry for user " + userId + ", check Login Module.");
-               }
-            }
-
-            if (state != null)
-            {
-               conversationRegistry.register(stateKey, state);
-               if (LOG.isDebugEnabled())
-               {
-                  LOG.debug("Register Conversation state " + httpSession.getId());
-               }
-            }
-         }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Looking for Conversation State " + httpSession.getId());
       }
-      else
-      {
-         state = new ConversationState(new Identity(IdentityConstants.ANONIM));
+
+      state = getConversationRegistry(container).getState(stateKey);
+
+      if (state != null && !userId.equals(state.getIdentity().getUserId())) {
+        state = null;
+        getConversationRegistry(container).unregister(stateKey, false);
+        LOG.debug("The current conversation state with the session ID " + httpSession.getId() + " does not belong to the user " +
+            userId + ". The conversation state registry will be updated.");
       }
-      return state;
-   }
 
-   /**
-    * {@inheritDoc}
-    */
-   public void destroy()
-   {
-      // nothing to do.
-   }
+      if (state == null) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Conversation State not found, try create new one.");
+        }
 
+        Identity identity = getIdentityRegistry(container).getIdentity(userId);
+        if (identity != null) {
+          state = new ConversationState(identity);
+          // Keep subject as attribute in ConversationState.
+          state.setAttribute(ConversationState.SUBJECT, identity.getSubject());
+        } else {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Not found identity for " + userId + " try to restore it. ");
+          }
+
+          Authenticator authenticator = container.getComponentInstanceOfType(Authenticator.class);
+          try {
+            identity = authenticator.createIdentity(userId);
+            getIdentityRegistry(container).register(identity);
+          } catch (Exception e) {
+            LOG.error("Unable restore identity. " + e.getMessage(), e);
+          }
+
+          if (identity != null) {
+            state = new ConversationState(identity);
+          }
+        }
+
+        if (state != null) {
+          getConversationRegistry(container).register(stateKey, state);
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Register Conversation state " + httpSession.getId());
+          }
+        }
+      }
+    } else {
+      state = new ConversationState(new Identity(IdentityConstants.ANONIM));
+    }
+    return state;
+  }
+
+  public ConversationRegistry getConversationRegistry(ExoContainer container) {
+    if (conversationRegistry == null) {
+      conversationRegistry = container.getComponentInstanceOfType(ConversationRegistry.class);
+    }
+    return conversationRegistry;
+  }
+
+  public IdentityRegistry getIdentityRegistry(ExoContainer container) {
+    if (identityRegistry == null) {
+      identityRegistry = container.getComponentInstanceOfType(IdentityRegistry.class);
+    }
+    return identityRegistry;
+  }
 }

--- a/exo.core.component.security.core/src/main/resources/conf/portal/configuration.xml
+++ b/exo.core.component.security.core/src/main/resources/conf/portal/configuration.xml
@@ -21,6 +21,12 @@
    xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
    <component>
+      <type>org.exoplatform.services.security.IdentityRegistry</type>
+   </component>
+   <component>
+      <type>org.exoplatform.services.security.ConversationRegistry</type>
+   </component>
+   <component>
       <key>org.exoplatform.services.security.RolesExtractor</key>
       <type>org.exoplatform.services.security.impl.DefaultRolesExtractorImpl</type>
       <init-params>

--- a/exo.core.component.security.core/src/test/java/org/exoplatform/services/security/SimpleStateKey.java
+++ b/exo.core.component.security.core/src/test/java/org/exoplatform/services/security/SimpleStateKey.java
@@ -18,28 +18,26 @@
  */
 package org.exoplatform.services.security;
 
-public final class SimpleStateKey implements StateKey
-{
+public final class SimpleStateKey implements StateKey {
 
-   private final String str;
+  private static final long serialVersionUID = -4390844600172144821L;
 
-   public SimpleStateKey(String str)
-   {
-      this.str = str;
-   }
+  private final String      str;
 
-   public boolean equals(Object obj)
-   {
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      return str.equals(((SimpleStateKey)obj).str);
-   }
+  public SimpleStateKey(String str) {
+    this.str = str;
+  }
 
-   public int hashCode()
-   {
-      return str.hashCode();
-   }
+  public boolean equals(Object obj) {
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    return str.equals(((SimpleStateKey) obj).str);
+  }
+
+  public int hashCode() {
+    return str.hashCode();
+  }
 
 }


### PR DESCRIPTION
Prior to this change, the ACL identities was cached in a HashMap rather than a Monitored Cache Instance. This change will transform the usage of HashMap to a Cache to make it possible to control its size and elements on runtime. In addition, using a cache instance will allow to monitor its usage and will avoid to have a memory leak (which may lead to an expansive diagnosis cost).

Resolves Meeds-io/meeds#3472