### PR TITLE
fix: Not allowing user synchro from ldap/ad if username contains white space - MEED-9484 - Meeds-io/meeds#3360

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
@@ -23,7 +23,6 @@ import java.util.*;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.services.organization.impl.UserImpl;
 import org.picocontainer.Startable;
 
@@ -851,6 +850,11 @@ public class IDMExternalStoreImportService implements Startable {
 
     boolean isModified = false;
     if (isNew) {
+      // Reject usernames containing whitespace before creating the user
+      if (username == null || containsWhitespace(username)) {
+        LOG.warn("Skipping creation of external user '{}': username contains whitespace", username);
+        return null;
+      }
       User externalUser = externalStoreService.getEntity(IDMEntityType.USER, username);
       externalUser.setOriginatingStore(OrganizationService.EXTERNAL_STORE);
 
@@ -1076,5 +1080,11 @@ public class IDMExternalStoreImportService implements Startable {
 
   public void setDeleteMissingEntriesFromInternalStore(boolean deleteMissingEntriesFromInternalStore) {
     this.deleteMissingEntriesFromInternalStore = deleteMissingEntriesFromInternalStore;
+  }
+
+  private boolean containsWhitespace(String username) {
+    if (username == null || username.isEmpty())
+      return false;
+    return username.codePoints().anyMatch(Character::isWhitespace);
   }
 }

--- a/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/api/IDMExternalStoreImportServiceTest.java
+++ b/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/api/IDMExternalStoreImportServiceTest.java
@@ -19,12 +19,15 @@
 package org.exoplatform.services.organization.api;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.exoplatform.services.organization.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,10 +37,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.exoplatform.container.StandaloneContainer;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.listener.ListenerService;
-import org.exoplatform.services.organization.BaseOrganizationService;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.UserProfile;
-import org.exoplatform.services.organization.UserProfileHandler;
 import org.exoplatform.services.organization.externalstore.IDMExternalStoreImportService;
 import org.exoplatform.services.organization.externalstore.IDMExternalStoreService;
 import org.exoplatform.services.organization.externalstore.model.IDMEntityType;
@@ -70,12 +69,14 @@ public class IDMExternalStoreImportServiceTest {
     StandaloneContainer.addConfigurationURL(containerConf);
     StandaloneContainer container = StandaloneContainer.getInstance();
 
-    organizationService =
-                        (BaseOrganizationService) container.getComponentInstance(org.exoplatform.services.organization.OrganizationService.class);
-    assertNotNull(organizationService);
+    organizationService = mock(OrganizationService.class);
+    UserHandler userHandler = mock(UserHandler.class);
+    when(organizationService.getUserHandler()).thenReturn(userHandler);
 
-    profileHandler = organizationService.getUserProfileHandler();
-    this.idmExternalStoreImportService = new IDMExternalStoreImportService(container,
+    profileHandler = mock(UserProfileHandler.class);
+    when(organizationService.getUserProfileHandler()).thenReturn(profileHandler);
+
+    this.idmExternalStoreImportService = new IDMExternalStoreImportService(null,
                                                                            organizationService,
                                                                            listenerService,
                                                                            idmExternalStoreService,
@@ -131,6 +132,23 @@ public class IDMExternalStoreImportServiceTest {
     verify(listenerService, atLeast(1)).broadcast(eq(IDMExternalStoreService.USER_PROFILE_ADDED_FROM_EXTERNAL_STORE),
                                                   anyObject(),
                                                   argThat(param -> param instanceof HashMap<?, ?>));
+  }
+
+  @Test
+  public void skipUserCreationWhenUsernameContainsWhitespace() throws Exception {
+    String usernameWithSpace = "john doe";
+
+    Method importUserMethod = IDMExternalStoreImportService.class.getDeclaredMethod("importUser",
+                                                                                    String.class,
+                                                                                    boolean.class,
+                                                                                    boolean.class,
+                                                                                    boolean.class);
+    importUserMethod.setAccessible(true);
+
+    Object result = importUserMethod.invoke(idmExternalStoreImportService, usernameWithSpace, false, true, true);
+
+    assertNull(result);
+    verify(organizationService.getUserHandler(), never()).createUser(any(User.class), anyBoolean());
   }
 
 }


### PR DESCRIPTION
This change will skip creation/update in IDMExternalStoreImportService when username contains whitespace