### PR TITLE
fix: Avoid NPE when updating user Memberships - EXO-81217

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/MembershipUpdateListener.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/MembershipUpdateListener.java
@@ -68,6 +68,10 @@ public class MembershipUpdateListener extends MembershipEventListener
       for (StateKey key : conversationRegistry.getStateKeys(userId))
       {
          ConversationState cstate = conversationRegistry.getState(key);
+         if (cstate == null) {
+           conversationRegistry.unregister(key);
+           continue;
+         }
          Identity identity = cstate.getIdentity();
          Iterator<MembershipEntry> iter = identity.getMemberships().iterator();
          while (iter.hasNext())
@@ -96,6 +100,10 @@ public class MembershipUpdateListener extends MembershipEventListener
       for (StateKey key : conversationRegistry.getStateKeys(userId))
       {
          ConversationState cstate = conversationRegistry.getState(key);
+         if (cstate == null) {
+           conversationRegistry.unregister(key);
+           continue;
+         }
          Identity identity = cstate.getIdentity();
          Iterator<MembershipEntry> iter = identity.getMemberships().iterator();
          boolean contains = false;


### PR DESCRIPTION
Prior to this change, when the user has multiple sessions opened including those which have expired, an NPE is observed when iterating through those sessions to update the user Memberships.
This change will avoid the NPE by continue the loop instead of throwing an error which will interrupt calling methods.