### PR TITLE
Fix: Apostrophe in username causes glitches in the display of a space's member list - MEED-9854 - meeds-io/meeds#3737. 

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
@@ -850,9 +850,28 @@ public class IDMExternalStoreImportService implements Startable {
 
     boolean isModified = false;
     if (isNew) {
-      // Reject usernames containing whitespace before creating the user
-      if (username == null || containsWhitespace(username)) {
-        LOG.warn("Skipping creation of external user '{}': username contains whitespace", username);
+      // Reject usernames containing whitespace or apostrophe before creating the user
+      if (username == null || username.isEmpty()) {
+        LOG.warn("Skipping creation of external user: username is null");
+        return null;
+      }
+
+      boolean hasWhitespace = containsWhitespace(username);
+      boolean hasApostrophe = containsApostrophe(username);
+
+      if (hasWhitespace || hasApostrophe) {
+        StringBuilder reason = new StringBuilder();
+        if (hasWhitespace) {
+          reason.append("whitespace");
+        }
+        if (hasApostrophe) {
+          if (reason.length() > 0) {
+            reason.append(" and ");
+          }
+          reason.append("apostrophe");
+        }
+
+        LOG.warn("Skipping creation of external user '{}': username contains {}", username, reason);
         return null;
       }
       User externalUser = externalStoreService.getEntity(IDMEntityType.USER, username);
@@ -1083,8 +1102,10 @@ public class IDMExternalStoreImportService implements Startable {
   }
 
   private boolean containsWhitespace(String username) {
-    if (username == null || username.isEmpty())
-      return false;
     return username.codePoints().anyMatch(Character::isWhitespace);
+  }
+
+  private boolean containsApostrophe(String username) {
+    return username.indexOf('\'') >= 0;
   }
 }

--- a/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/api/IDMExternalStoreImportServiceTest.java
+++ b/exo.core.component.organization.api/src/test/java/org/exoplatform/services/organization/api/IDMExternalStoreImportServiceTest.java
@@ -151,4 +151,38 @@ public class IDMExternalStoreImportServiceTest {
     verify(organizationService.getUserHandler(), never()).createUser(any(User.class), anyBoolean());
   }
 
+  @Test
+  public void skipUserCreationWhenUsernameContainsApostrophe() throws Exception {
+    String usernameWithApostrophe = "john's doe";
+
+    Method importUserMethod = IDMExternalStoreImportService.class.getDeclaredMethod("importUser",
+            String.class,
+            boolean.class,
+            boolean.class,
+            boolean.class);
+    importUserMethod.setAccessible(true);
+
+    Object result = importUserMethod.invoke(idmExternalStoreImportService, usernameWithApostrophe, false, true, true);
+
+    assertNull(result);
+    verify(organizationService.getUserHandler(), never()).createUser(any(User.class), anyBoolean());
+  }
+
+  @Test
+  public void skipUserCreationWhenUsernameIsEmpty() throws Exception {
+    String usernameEmpty = "";
+
+    Method importUserMethod = IDMExternalStoreImportService.class.getDeclaredMethod("importUser",
+            String.class,
+            boolean.class,
+            boolean.class,
+            boolean.class);
+    importUserMethod.setAccessible(true);
+
+    Object result = importUserMethod.invoke(idmExternalStoreImportService, usernameEmpty, false, true, true);
+
+    assertNull(result);
+    verify(organizationService.getUserHandler(), never()).createUser(any(User.class), anyBoolean());
+  }
+
 }


### PR DESCRIPTION
Before this change, when performing an LDAP synchronization: if at least one username contained an apostrophe, then opening spaces from the organization menu in the administration panel and creating a space binding for spacex with the platform/users group would result in the username being saved with illegal characters in the spacex member list. To fix this problem, a condition was added to check if the username contains an apostrophe, similar to how whitespace is handled. After this change, the creation/update process in IDMExternalStoreImportService is skipped when the username contains an apostrophe.
Resolves https://github.com/Meeds-io/meeds/issues/3737