### PR TITLE
feat: Review the operation Create User - MEED-10151 - Meeds-io/MIPs#242

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
@@ -121,18 +121,19 @@ public interface UserHandler
    /**
     * Disables automatically all enabled users who have been inactive for at least
     * the given number of days.
-    *
+    * <p>
     * A user is considered inactive when the last login date is older than
     * (current date - inactiveDays).
-    *
+    * <p>
     * The deactivation is marked as automatic by setting the
     * <code>automaticDeactivation</code> attribute to <code>true</code>.
     *
+    * @param groupId
     * @param inactiveDays the number of days of inactivity after which an enabled
-    *        user account will be automatically disabled
+    *                     user account will be automatically disabled
     * @return the number of users that have been automatically disabled
     */
-   default int disableInactiveUsers(int inactiveDays) {
+   default int disableInactiveUsers(String groupId, int inactiveDays) {
       throw new UnsupportedOperationException();
    }
 

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/mock/DummyOrganizationService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/mock/DummyOrganizationService.java
@@ -361,7 +361,7 @@ public class DummyOrganizationService extends BaseOrganizationService
       }
 
       @Override
-      public int disableInactiveUsers(int inactiveDays) {
+      public int disableInactiveUsers(String groupId, int inactiveDays) {
          return 0;
       }
 


### PR DESCRIPTION
This change will treat the following tasks:
- Review the Create User operation.
- Review the operation Enable User.
- Review the operation Disable User.
- Allow to specify a time for group members.
- Do not deactivate automatically user when platform admin.

In addition, this change adds a new String parameter `groupId` to the `disableInactiveUsers` method. This `groupId` represents the ID of the group to which the automatic deactivation will be applied. We also added an extra condition to prevent deactivating users who belong to the admin group. On the analytics side, a new attribute `User Source` has been added to indicate the original source of user creation and the labels of the other attributes have also been updated.
