### PR TITLE
fix: Space created by non admin results to not found page - MEED-10255 - Meeds-io/meeds#4053

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/MembershipUpdateListener.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/MembershipUpdateListener.java
@@ -23,6 +23,8 @@ import org.exoplatform.services.organization.MembershipEventListener;
 import org.exoplatform.services.security.ConversationRegistry;
 import org.exoplatform.services.security.IdentityRegistry;
 
+import static org.exoplatform.container.component.RequestLifeCycle.restartTransaction;
+
 public class MembershipUpdateListener extends MembershipEventListener {
 
   private final ConversationRegistry conversationRegistry;
@@ -47,6 +49,7 @@ public class MembershipUpdateListener extends MembershipEventListener {
   private void refreshUserIdentity(String username) {
     conversationRegistry.unregisterByUserId(username);
     identityRegistry.unregister(username);
+    restartTransaction();
   }
 
 }


### PR DESCRIPTION
Prior to this change, creating a new space with a simple user redirected the user to the Not Found page, making the space inaccessible. The issue occurred because the role was not properly fetched due to the request lifecycle transaction not being restarted. This update restarts the transaction after the membership update, ensuring the role is correctly retrieved and resolving the issue.

Resolves Meeds-io/meeds#4053
