### PR TITLE
fix: allow to not delete memberships during synchro if the information is not present in LDAP - EXO-87414

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreImportService.java
@@ -59,6 +59,10 @@ public class IDMExternalStoreImportService implements Startable {
 
   public static final String      EXTERNAL_STORE_DELETE_MISSING_ENTRIES     = "exo.idm.externalStore.entries.missing.delete";
 
+  public static final String      EXTERNAL_STORE_DELETE_MISSING_USER_MEMBERSHIP     = "exo.idm.externalStore.user.memberships.update.delete";
+
+  public static final String      EXTERNAL_STORE_DELETE_MISSING_GROUP_MEMBERSHIP     = "exo.idm.externalStore.group.memberships.update.delete";
+
   private ExoContainer            container;
 
   private OrganizationService     organizationService;
@@ -81,6 +85,10 @@ public class IDMExternalStoreImportService implements Startable {
 
   private boolean                 interrupted;
 
+  private boolean                 updateDeletedUserMemberships = true;
+
+  private boolean                 updateDeletedGroupMemberships = true;
+
   public IDMExternalStoreImportService(ExoContainer container,
                                        OrganizationService organizationService,
                                        ListenerService listenerService,
@@ -95,6 +103,12 @@ public class IDMExternalStoreImportService implements Startable {
     this.externalStoreService = externalStoreService;
     this.jobSchedulerService = jobSchedulerService;
     if (params != null) {
+      if (params.containsKey(EXTERNAL_STORE_DELETE_MISSING_USER_MEMBERSHIP)) {
+        updateDeletedUserMemberships = Boolean.parseBoolean(params.getValueParam(EXTERNAL_STORE_DELETE_MISSING_USER_MEMBERSHIP).getValue());
+      }
+      if (params.containsKey(EXTERNAL_STORE_DELETE_MISSING_GROUP_MEMBERSHIP)) {
+        updateDeletedGroupMemberships = Boolean.parseBoolean(params.getValueParam(EXTERNAL_STORE_DELETE_MISSING_GROUP_MEMBERSHIP).getValue());
+      }
       if (params.containsKey(EXTERNAL_STORE_IMPORT_CRON_EXPRESSION)) {
         scheduledDataImportJobCronExpression = params.getValueParam(EXTERNAL_STORE_IMPORT_CRON_EXPRESSION).getValue();
       }
@@ -630,20 +644,21 @@ public class IDMExternalStoreImportService implements Startable {
       internalMemberships = organizationService.getMembershipHandler().findMembershipsByGroup(group);
     }
     Collection externalMemberships = externalStoreService.getEntity(IDMEntityType.GROUP_MEMBERSHIPS, groupId);
-    importMemberships(IDMEntityType.GROUP_MEMBERSHIPS, externalMemberships, internalMemberships);
+    importMemberships(IDMEntityType.GROUP_MEMBERSHIPS, externalMemberships, internalMemberships, updateDeleted);
   }
 
   @SuppressWarnings({ "rawtypes" })
   private void importUserMemberships(String username, boolean updateModified, boolean updateDeleted) throws Exception {
     Collection internalMemberships = organizationService.getMembershipHandler().findMembershipsByUser(username);
     Collection externalMemberships = externalStoreService.getEntity(IDMEntityType.USER_MEMBERSHIPS, username);
-    importMemberships(IDMEntityType.USER_MEMBERSHIPS, externalMemberships, internalMemberships);
+    importMemberships(IDMEntityType.USER_MEMBERSHIPS, externalMemberships, internalMemberships, updateDeleted);
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   private void importMemberships(IDMEntityType<?> entityType,
                                  Collection externalMemberships,
-                                 Collection internalMemberships) throws Exception {
+                                 Collection internalMemberships,
+                                 boolean updateDeleted) throws Exception {
     if (externalMemberships != null && !externalMemberships.isEmpty()) {
       List membershipsToAdd = new ArrayList(externalMemberships);
       for (Object object : externalMemberships) {
@@ -657,17 +672,18 @@ public class IDMExternalStoreImportService implements Startable {
         importMembership(entityType, membership, false, false);
       }
     }
+    if (updateDeleted) {
+      // Check deleted user memberships on external store
+      for (Object object : internalMemberships) {
+        Membership membership = (Membership) object;
+        Group group = organizationService.getGroupHandler().findGroupById(membership.getGroupId());
+        User user = organizationService.getUserHandler().findUserByName(membership.getUserName(), UserStatus.ANY);
 
-    // Check deleted user memberships on external store
-    for (Object object : internalMemberships) {
-      Membership membership = (Membership) object;
-      Group group = organizationService.getGroupHandler().findGroupById(membership.getGroupId());
-      User user = organizationService.getUserHandler().findUserByName(membership.getUserName(), UserStatus.ANY);
-
-      if (group == null || user == null || (!group.isInternalStore() && !user.isInternalStore()
-          && (externalMemberships == null || !externalMemberships.contains(membership)))) {
-        LOG.trace("Remove deleted membership from external store '{}'", membership);
-        organizationService.getMembershipHandler().removeMembership(membership.getId(), true);
+        if (group == null || user == null || (!group.isInternalStore() && !user.isInternalStore()
+            && (externalMemberships == null || !externalMemberships.contains(membership)))) {
+          LOG.trace("Remove deleted membership from external store '{}'", membership);
+          organizationService.getMembershipHandler().removeMembership(membership.getId(), true);
+        }
       }
     }
   }
@@ -993,9 +1009,9 @@ public class IDMExternalStoreImportService implements Startable {
         // by IDM principal IDM removal
         if (IDMOperationType.ADD_OR_UPDATE.equals(queueEntry.getOperationType())) {
           if (entityType.equals(IDMEntityType.USER)) {
-            importEntityToInternalStore(IDMEntityType.USER_MEMBERSHIPS, queueEntry.getEntityId(), true, true);
+            importEntityToInternalStore(IDMEntityType.USER_MEMBERSHIPS, queueEntry.getEntityId(), true, updateDeletedUserMemberships);
           } else if (entityType.equals(IDMEntityType.GROUP)) {
-            importEntityToInternalStore(IDMEntityType.GROUP_MEMBERSHIPS, queueEntry.getEntityId(), true, true);
+            importEntityToInternalStore(IDMEntityType.GROUP_MEMBERSHIPS, queueEntry.getEntityId(), true, updateDeletedGroupMemberships);
           }
         }
 
@@ -1113,5 +1129,15 @@ public class IDMExternalStoreImportService implements Startable {
 
   private boolean containsApostrophe(String username) {
     return username.indexOf('\'') >= 0;
+
   }
+
+  public boolean isUpdateDeletedUserMemberships() {
+    return this.updateDeletedUserMemberships;
+  }
+
+  public boolean isUpdateDeletedGroupMemberships() {
+    return this.updateDeletedGroupMemberships;
+  }
+
 }

--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreManagedBean.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/externalstore/IDMExternalStoreManagedBean.java
@@ -203,7 +203,7 @@ public class IDMExternalStoreManagedBean implements Startable {
         getExternalStoreImportService().importEntityToInternalStore(IDMEntityType.GROUP_MEMBERSHIPS,
                                                                     entityId,
                                                                     true,
-                                                                    true);
+                                                                    getExternalStoreImportService().isUpdateDeletedGroupMemberships());
       }
     } finally {
       end();


### PR DESCRIPTION
Sometimes in LDAP, the user membership are not store in 2-directions (group to user with member attribute AND user to group with memberOf attribute) but only in one direction (group to user OR user to group). In this case, when synchronizing it, membership can be removed in exo : If it is stored in group-to-user direction, when you synchronize the user, membership are not seen and then removed in exo. If it is stored in user-to-group direction, when you synchronize the group, membership are not seen and then removed in exo.

This commit add 2 properties to be able to not delete the membership is not present in user or group object exo.idm.externalStore.user.memberships.update.delete exo.idm.externalStore.group.memberships.update.delete

In addition, the commit ensure to correctly use this attribute to ignore membership which are not present it the attribute is true

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
